### PR TITLE
Force agregate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .bundle
 rdoc
 Gemfile.lock
-
+.rvmrc

--- a/lib/mongoid/taggable.rb
+++ b/lib/mongoid/taggable.rb
@@ -22,10 +22,10 @@ module Mongoid::Taggable
 
     delegate :convert_string_tags_to_array, :aggregate_tags!, :to => 'self.class'
 
-    set_callback :create,  :after,  :aggregate_tags!
-    set_callback :destroy, :after,  :aggregate_tags!
+    set_callback :create,  :after,  :aggregate_tags!, :if => proc { self.class.aggregate_tags? }
+    set_callback :destroy, :after,  :aggregate_tags!, :if => proc { self.class.aggregate_tags? }
     set_callback :save,    :before, :dedup_tags!,     :if => proc { changes.include?(tags_field.to_s) }
-    set_callback :save,    :after,  :aggregate_tags!, :if => proc { changes.include?(tags_field.to_s) }
+    set_callback :save,    :after,  :aggregate_tags!, :if => proc { changes.include?(tags_field.to_s) and self.class.aggregate_tags? }
   end
 
   module ClassMethods
@@ -93,8 +93,6 @@ module Mongoid::Taggable
     # Execute map/reduce operation to aggregate tag counts for document
     # class
     def aggregate_tags!
-      return unless aggregate_tags?
-
       map = "function() {
         if (!this.#{tags_field}) {
           return;

--- a/spec/mongoid/taggable_spec.rb
+++ b/spec/mongoid/taggable_spec.rb
@@ -130,6 +130,12 @@ describe Mongoid::Taggable do
       MyModel.tags.should == []
     end
 
+    it "can be forced" do
+      MyModel.create!(:tags => "sample,tags")
+      MyModel.aggregate_tags!
+      MyModel.tags.should == %w[sample tags]
+    end
+
     context "when enabled" do
       before :all do
         MyModel.tag_aggregation = true


### PR DESCRIPTION
Sometimes we want to disable the aggregation on the front end time, and push it to a background task like resque. This commit allows the aggregate_tags! function to be able to be called even if aggregation is set to false.
