### PR TITLE
Passing aggregation options to the map/reduce ruby driver method

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,22 @@ Post.tags_with_weight # will retrieve:
 
 You may also trigger aggregation on-demand rather than setting the automatic option, to run it from a background task for instance, by calling `Post.aggregate_tags!`.
 
+If you need to modify the criteria used for the aggregation you may do so as an option to 'taggable':
+
+```ruby
+class Post
+  include Mongoid::Document
+  include Mongoid::Taggable
+  
+  field :title
+  field :content
+  field :published, :type => Boolean
+  
+  taggable :aggregation_options => { :query => { :published => true } }
+```
+
+A full list of available options can be found at [the ruby driver API](http://api.mongodb.org/ruby/current/Mongo/Collection.html#map_reduce-instance_method) (consult the appropriate version).
+
 Changing default separator
 --------------------------
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ class Post
   field :published, :type => Boolean
   
   taggable :aggregation_options => { :query => { :published => true } }
+end
 ```
 
 A full list of available options can be found at [the ruby driver API](http://api.mongodb.org/ruby/current/Mongo/Collection.html#map_reduce-instance_method) (consult the appropriate version).


### PR DESCRIPTION
I added field :tag_aggregation_options to be sent to the map_reduce method on #aggregate_tags!.

This is useful whenever you want to override the :out options (very unlikely), or when you want to set other options, like :query, :sort and :limit.

I'm personally using this to avoid disabled models from being counted, as we are required to soft-delete information.
