### PR TITLE
Add tags_before_type_cast method

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Then in your form, for example:
   </p>
   <p>
     <%= f.label :tags %><br />
-    <%= text_field_tag 'post[tags]', (@post.tags.join(', ') if @post.tags) %>
+    <%= f.text_field :tags %>
   </p>
   <p>
     <button type="submit">Send</button>
@@ -57,7 +57,7 @@ Then in your form, for example:
 <% end %>
 ```
 
-You can of course use helpers or a `FormBuilder` extension to express this in a prettier way. If you're using SimpleForm for example, a custom input can be found in [this Gist](https://gist.github.com/1172956), usable as `f.input :tags` within `simple_form_for` blocks. The text field should receive a list of tags separated by comma (below in this document you will see how to change the separator).
+The text field should receive a list of tags separated by comma (below in this document you will see how to change the separator).
 
 Your document will have a custom `tags=` setter which can accept either an ordinary Array or this separator-delineated String.
 

--- a/lib/mongoid/taggable.rb
+++ b/lib/mongoid/taggable.rb
@@ -135,6 +135,12 @@ module Mongoid::Taggable
       end
       alias_method_chain "#{name}=", :taggable
 
+      # Define value_before_type_cast method to format array in input field as comma separated list
+      # @see ActionView::Helpers::InstanceTag::value_before_type_cast
+      define_method "#{name}_before_type_cast" do
+        self.send(name).join("#{tags_separator} ") if self.send(name)
+      end
+
       # Dynamically named class methods, for aggregation
       (class << self; self; end).instance_eval do
         # get an array with all defined tags for this model, this list returns

--- a/spec/mongoid/taggable_spec.rb
+++ b/spec/mongoid/taggable_spec.rb
@@ -107,6 +107,11 @@ describe Mongoid::Taggable do
       article.keywords = "some,new,tag"
       article.keywords.should == %w[some new tag]
     end
+
+    it "#keywords_before_type_cast" do
+      article.keywords = "some,new,tag"
+      article.keywords_before_type_cast.should eq "some, new, tag"
+    end
   end
 
   context "changing separator" do
@@ -209,6 +214,12 @@ describe Mongoid::Taggable do
     end
   end
 
+  context "#tags_before_type_cast" do
+    subject { MyModel.new(:tags => %w[some new tag]) }
+
+    its(:tags_before_type_cast) { should eq "some, new, tag" }
+  end
+
   context "#self.tagged_with" do
     let!(:models) do
       [
@@ -256,6 +267,11 @@ describe Mongoid::Taggable do
       Editorial.create!(:keywords => 'satire politics')
       Article.keywords_with_weight.should include(['satire', 3])
       Editorial.keywords_with_weight.should include(['satire', 3])
+    end
+
+    it "#keywords_before_type_cast" do
+      editorial.keywords = %w[some new tag]
+      editorial.keywords_before_type_cast.should eq "some  new  tag"
     end
   end
 


### PR DESCRIPTION
I added a [type_before_type_cast](http://api.rubyonrails.org/classes/ActionView/Helpers/InstanceTag.html#method-c-value_before_type_cast) method.

basically it does the same as https://gist.github.com/1172956 but by providing a type_before_type_cast method which is then used by Rails FormHelper.

This way it is independent of SimpleForm and has no negative side effects on the generated HTML.
