### PR TITLE
Fix ActiveConcern::InstanceMethods deprecation warning

### DIFF
--- a/lib/mongoid/taggable.rb
+++ b/lib/mongoid/taggable.rb
@@ -160,15 +160,13 @@ module Mongoid::Taggable
     end
   end
 
-  module InstanceMethods
-    # De-duplicate tags, case-insensitively, but preserve case given first
-    def dedup_tags!
-      tags = read_attribute(tags_field)
-      tags = tags.reduce([]) do |uniques, tag|
-        uniques << tag unless uniques.map(&:downcase).include?(tag.downcase)
-        uniques
-      end
-      write_attribute(tags_field, tags)
+  # De-duplicate tags, case-insensitively, but preserve case given first
+  def dedup_tags!
+    tags = read_attribute(tags_field)
+    tags = tags.reduce([]) do |uniques, tag|
+      uniques << tag unless uniques.map(&:downcase).include?(tag.downcase)
+      uniques
     end
+    write_attribute(tags_field, tags)
   end
 end


### PR DESCRIPTION
This fixes a deprecation warning that began after I upgraded a project
to Rails 3.2. As the warning says, there is no reason to use the
InstanceMethods module since instance methods will get included without
any help from ActiveConcern.
